### PR TITLE
Set Base->$options default as an array to avoid PHP warning.

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -74,7 +74,7 @@ class Base {
 	 * Loads options to private static variable.
 	 */
 	public function __construct() {
-		self::$options = get_site_option( 'github_updater' );
+		self::$options = get_site_option( 'github_updater', array());
 		$this->add_headers();
 	}
 


### PR DESCRIPTION
When installing the plugin on my dev environment I get the following warning:

```Warning: array_diff_key(): Argument #1 is not an array in plugins/github-updater/src/GitHub_Updater/Settings.php on line 301```

The issue seems to originate on line 77 of Base.php, in the constructor where the get_site_option was not given a default value.

I also changed the declaration on line 63, just to make it clearer that $options should be an array.

