### PR TITLE
Split settings and plugins & themes on wp hook

### DIFF
--- a/github-updater.php
+++ b/github-updater.php
@@ -68,4 +68,5 @@ new $instantiate;
  * InfiniteWP, ManageWP, MainWP, and iThemes Sync will load and use all
  * of GitHub_Updater's methods, especially renaming.
  */
-add_action( 'init', array( 'Fragen\\GitHub_Updater\\Base', 'init' ) );
+add_action( 'admin_init', array( 'Fragen\\GitHub_Updater\\Base', 'init' ) );
+add_action( 'init', array( 'Fragen\\GitHub_Updater\\Base', 'init_settings' ) );

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -109,6 +109,13 @@ class Base {
 		if ( current_user_can( 'update_themes' ) ) {
 			new Theme();
 		}
+	}
+
+	/**
+	 * Instantiate Fragen\GitHub_Updater\Settings on admin
+	 * 
+	 */
+	public static function init_settings(){
 		if ( is_admin() && ( current_user_can( 'update_plugins' ) || current_user_can( 'update_themes' ) ) ) {
 			new Settings();
 		}


### PR DESCRIPTION
On profiling my own plugins with [P3] (https://wordpress.org/plugins/p3-profiler/), I noticed that Github Updater uses a lot of time to complete it's api requests. While most of this needs to gets done in the admin, it seems to get checked on every init-hook in WordPress...

I've split the plugins & themes init-functions with the settings-init, so plugins and themes init on the WordPress hook 'admin_init'. settings still hooks into init, otherwise the settings-page wouldn't fire.

I've added three speed-tests:
one on init (the slowest)
one on admin_init (the fastest, but without the settings-page firing)
and one split up (like in this pull-request) which makes everything work again.

![like pull request](https://cloud.githubusercontent.com/assets/3257545/8048058/363d7f5c-0e4d-11e5-9881-8d47db865d22.png)
![with init](https://cloud.githubusercontent.com/assets/3257545/8048057/363b7978-0e4d-11e5-94fc-319ef636376e.png)
![with admin_init](https://cloud.githubusercontent.com/assets/3257545/8048056/363ab128-0e4d-11e5-9265-6703fc5c5a57.png)


