### PR TITLE
Update plugins / themes via CRON

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -145,7 +145,7 @@ class Base {
 	 * Performs actual metadata fetching
 	 */
 	function forced_meta_update() {
-		error_log("Inside forced update!");
+		//error_log("Inside forced update!");
 		new Plugin(true);
 		new Theme(true);
 	}

--- a/src/GitHub_Updater/Theme.php
+++ b/src/GitHub_Updater/Theme.php
@@ -38,9 +38,24 @@ class Theme extends Base {
 	protected $tag = false;
 
 	/**
-	 * Constructor.
+	 * Force meta update toggle
+	 *
+	 * @var bool
 	 */
-	public function __construct() {
+	protected $force_meta_update = false;
+
+	/**
+	 * Constructor
+	 *
+	 * @param bool|false $force_meta_update whether we should force meta updating
+	 */
+	public function __construct($force_meta_update = false) {
+
+		$this->force_meta_update = $force_meta_update;
+
+		if ( isset( $_GET['force-check'] ) ) {
+			$this->delete_all_transients( 'themes' );
+		}
 
 		/*
 		 * Get details of git sourced themes.
@@ -49,9 +64,7 @@ class Theme extends Base {
 		if ( empty( $this->config ) ) {
 			return false;
 		}
-		if ( isset( $_GET['force-check'] ) ) {
-			$this->delete_all_transients( 'themes' );
-		}
+
 
 		foreach ( (array) $this->config as $theme ) {
 			$this->repo_api = null;


### PR DESCRIPTION
This PR stems from the discussion in #242 

By introducing the `$force` option to get_plugin_meta() and `$force_meta_update` to the Plugin and Theme class constructors, we no longer make external calls on a regular (admin) page load.

By introducing a number of hooks in the new `background_update()` function, we make sure that the plugin metadata will attempt to refresh on the following conditions:

* Visiting plugin page
* Visiting update page
* When`wp_update_plugins` and `wp_update_themes` hooks run. (These run on the CRON jobs with the same name. WordPress automatically sets up these jobs to run every 12 hours.)

Basically, on the above conditions, the plugin will work as it did before. On all other pages it will *not* attempt to grab data remotely. (That is what the CRON job is for!)

You can try this out by installing the Crontrol plugin and manually running the `wp_update_plugins` and `wp_update_themes` CRON jobs.

I made this as a minimal working proof of concept, using the existing code structure. I haven't tested branch switching but seeing as the changes to the code are minimal, it should work as before. Any feedback welcome.