### PR TITLE
Refactoring background updates for a cleaner interface

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -169,17 +169,31 @@ class Base {
 	 * Piggyback on built-in update function to get metadata.
 	 */
 	public function background_update() {
-		add_action( 'wp_update_plugins', array( &$this, 'forced_meta_update' ) );
-		add_action( 'wp_update_themes', array( &$this, 'forced_meta_update' ) );
+		add_action( 'wp_update_plugins', array( &$this, 'forced_meta_update_plugins' ) );
+		add_action( 'wp_update_themes', array( &$this, 'forced_meta_update_themes' ) );
 		add_action( 'wp_ajax_nopriv_ithemes_sync_request', array( &$this, 'forced_meta_update' ) );
 	}
 
 	/**
-	 * Performs actual metadata fetching.
+	 * Performs actual metadata fetching for plugins.
 	 */
-	function forced_meta_update() {
-		Plugin::$object = Plugin::instance( true );
-		Theme::$object  = Theme::instance( true );
+	function forced_meta_update_plugins() {
+
+		//Initialize instances
+		Plugin::$object = Plugin::instance( );
+
+		//Perform meta update, woo!
+		Plugin::$object->remote_plugin_meta_update();
+	}
+
+	/**
+	 * Performs actual metadata fetching for themes.
+	 */
+	function forced_meta_update_themes() {
+		Theme::$object  = Theme::instance( );
+
+		//TODO: Make work with themes as well
+		//Plugin::$object->remote_theme_meta_update();
 	}
 
 	/**

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -145,9 +145,7 @@ class Base {
 			}
 		}
 
-		if ( in_array( $pagenow, array_unique( $admin_pages ) ) ||
-		     ( defined( 'DOING_AJAX' ) && DOING_AJAX )
-		) {
+		if ( in_array( $pagenow, array_unique( $admin_pages ) ) ) {
 			$force_meta_update = true;
 		}
 

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -150,10 +150,21 @@ class Base {
 		}
 
 		if ( current_user_can( 'update_plugins' ) ) {
-			Plugin::$object = Plugin::instance( $force_meta_update );
+
+			//Get current object instance
+			Plugin::$object = Plugin::instance();
+
+			//If we should potentially update plugin meta, let's do it!
+			if($force_meta_update) {
+				Plugin::$object->remote_plugin_meta_update();
+			}
 		}
 		if ( current_user_can( 'update_themes' ) ) {
-			Theme::$object = Theme::instance( $force_meta_update );
+			Theme::$object = Theme::instance();
+			if($force_meta_update) {
+				//TODO: Implement
+				//Theme::$object->remote_update();
+			}
 		}
 		if ( is_admin() &&
 		     ( current_user_can( 'update_plugins' ) || current_user_can( 'update_themes' ) )

--- a/src/GitHub_Updater/Settings.php
+++ b/src/GitHub_Updater/Settings.php
@@ -335,14 +335,22 @@ class Settings extends Base {
 		$ghu_options_keys = array();
 		$plugin = get_site_transient( 'ghu_plugin' );
 		$theme  = get_site_transient( 'ghu_theme' );
+
 		if ( ! $plugin ) {
-			$plugin = Plugin::instance( true );
+			$plugin = Plugin::instance( );
 		}
 		if ( ! $theme ) {
-			$theme = Theme::instance( true );
+			$theme = Theme::instance( );
 		}
+
 		$ghu_plugins = $plugin->config;
 		$ghu_themes  = $theme->config;
+
+		//FIXME: Temporary until we refactor the Plugins class
+		if(!is_array($ghu_themes)) {
+			$ghu_themes = array();
+		}
+
 		$ghu_tokens  = array_merge( $ghu_plugins, $ghu_themes );
 
 		foreach ( $ghu_tokens as $token ) {
@@ -418,6 +426,8 @@ class Settings extends Base {
 				array( 'id' => $setting_field['callback'] )
 			);
 		}
+
+		//var_dump($ghu_tokens);die();
 
 		/*
 		 * Unset options that are no longer present and update options.


### PR DESCRIPTION
The goal of this commit is to refactor how background updates are handled to provide a simpler interface.

* Invoking the constructor of Theme and Plugin classes no longer trigger any kind of updating by itself
* Instead, the functions `remote_plugin_meta_update` and `remote_theme_meta_update` need to be invoked in order to trigger a remote update. This lets us create the classes without having to worry about whether they are updating or not.
* AJAX no longer triggers remote update, ever.
* Broke up forced_meta_update into separate theme/plugin functions

**Known issues**: 
This is a work in progress / suggestion. 

* Plugin class refactoring is done but Theme class still needs some work.
* Branch switcher does not work because it's placed in an odd location, see: https://github.com/afragen/github-updater/pull/279/files#diff-9fc7f6ea61542ac484e16a01eb4d61e1R143