### PR TITLE
csx: fixes error message in Messages.php: 'unknown index page in line…

### DIFF
--- a/src/GitHub_Updater/Messages.php
+++ b/src/GitHub_Updater/Messages.php
@@ -39,7 +39,7 @@ class Messages extends Base {
 
 		if (
 			! in_array( $pagenow, array_merge( $update_pages, $settings_pages ) ) ||
-			( in_array( $pagenow, $settings_pages ) && 'github-updater' !== $_GET['page'] )
+			( in_array( $pagenow, $settings_pages ) && ( ! isset($_GET['page']) || 'github-updater' !== $_GET['page'] ) )
 		) {
 			return false;
 		}


### PR DESCRIPTION
… 43'. This is b/c $_GET['page'] is not checked if it exists.