### PR TITLE
Rest api

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -191,54 +191,8 @@ class Base {
 	 * Ajax endpoint for rest updates.
 	 */
 	public function ajax_update() {
-		try {
-			$json_encode_flags=0;
-			if (defined("JSON_PRETTY_PRINT"))
-				$json_encode_flags=JSON_PRETTY_PRINT;
-
-			if (!isset($_REQUEST["key"]) || $_REQUEST["key"]!=get_site_option('github_updater_api_key'))
- 				throw new \Exception("Bad api key.");
-
-			$tag="master";
-			if (isset($_REQUEST["tag"]) && $_REQUEST["tag"])
-				$tag=$_REQUEST["tag"];
-
-			if (isset($_REQUEST["committish"]) && $_REQUEST["committish"])
-				$tag=$_REQUEST["committish"];
-
-			$upgrader_skin=new JsonUpgraderSkin();
-
-			if (isset($_REQUEST["plugin"]) && $_REQUEST["plugin"])
-				Plugin::instance()->update_single_plugin($_REQUEST["plugin"], $tag, $upgrader_skin);
-
-			else if (isset($_REQUEST["theme"]) && $_REQUEST["theme"])
-				Theme::instance()->update_single_theme($_REQUEST["theme"], $tag, $upgrader_skin);
-
-			else
-				throw new \Exception("No plugin or theme specified for update.");
-
-			if ($upgrader_skin->error)
-				throw new \Exception("Upgrade error.");
-		}
-
-		catch (\Exception $e) {
-			http_response_code(500);
-			header('Content-Type: application/json');
-
-			echo json_encode(array(
-				"message"=>$e->getMessage(),
-				"error"=>TRUE
-			),$json_encode_flags);
-			exit;
-		}
-
-		header('Content-Type: application/json');
-
-		echo json_encode(array(
-			"success"=>TRUE,
-			"messages"=>$upgrader_skin->messages,
-		),$json_encode_flags);
-		exit;
+		$rest_update=new RestUpdate();
+		$rest_update->process_request();
 	}
 
 	/**

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -188,21 +188,6 @@ class Base {
 	}
 
 	/**
-	 * Fail hard with a JSON message.
-	 */
-	private function ajax_fail($message, $code=500) {
-		http_response_code($code);
-		header('Content-Type: application/json');
-
-		echo json_encode(array(
-			"message"=>$message,
-			"error"=>TRUE
-		),JSON_PRETTY_PRINT);
-
-		exit;
-	}
-
-	/**
 	 * Ajax endpoint for rest updates.
 	 */
 	public function ajax_update() {

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -212,149 +212,56 @@ class Base {
 	}
 
 	/**
-	 * Update theme via ajax.
-	 */
-	private function ajax_update_theme($themeName) {
-		if (!isset($_REQUEST["key"]) || $_REQUEST["key"]!=get_site_option('github_updater_api_key'))
-			$this->ajax_fail("Bad api key.");
-
-		Theme::$object = Theme::instance();
-		$themes=Theme::$object->get_theme_meta();
-		$updateTheme=NULL;
-
-		foreach ($themes as $theme) {
-			if ($theme->repo==$themeName)
-				$updateTheme=$theme;
-		}
-
-		if (!$updateTheme)
-			$this->ajax_fail("Theme not found.");
-
-		$startsWith="https://github.com/";
-		if (substr($updateTheme->uri,0,strlen($startsWith))!=$startsWith)
-			$this->ajax_fail("Currently only GitHub themes can be updated through tihs api.");
-
-		$repo=str_replace("https://github.com/","",$updateTheme->uri);
-		$packageUrl="https://api.github.com/repos/$repo/zipball/$tag";
-		echo "packageUrl: $packageUrl\n";
-
-		$token=self::$options["github_access_token"];
-
-		if ($token)
-			$packageUrl.="?access_token=$token";
-
-		$current = get_site_transient( 'update_themes' );
-
-		// We don't know which version we will be downloading, it will simply be the 
-		// one given by the tag. We pass NULL to "new_version" which isn't documented
-		// anywhere, but seems to work.
-		$transientEntry=array(
-			"theme"=>$updateTheme->repo,
-			"new_version"=>NULL,
-			"url"=>$updateTheme->uri,
-			"package"=>$packageUrl
-		);
-
-		$current->response[$updateTheme->repo]=$transientEntry;
-		set_site_transient('update_themes', $current);
-
-		$repo=$updateTheme->repo;
-
-		$skin=new JsonUpgraderSkin();
-		$upgrader = new \Theme_Upgrader($skin);
-		$upgrader->upgrade($updateTheme->repo);
-
-		return $skin;
-	}
-
-	/**
-	 * Update plugin via ajax.
-	 */
-	private function ajax_update_plugin($pluginName, $tag) {
-		Plugin::$object = Plugin::instance();
-		$plugins=Plugin::$object->get_plugin_meta();
-		$updatePlugin=NULL;
-
-		foreach ($plugins as $plugin) {
-			if ($plugin->repo==$pluginName)
-				$updatePlugin=$plugin;
-		}
-
-		if (!$updatePlugin)
-			$this->ajax_fail("Plugin not found.");
-
-		$startsWith="https://github.com/";
-		if (substr($updatePlugin->uri,0,strlen($startsWith))!=$startsWith)
-			$this->ajax_fail("Currently only GitHub plugins can be updated through tihs api.");
-
-		$repo=str_replace("https://github.com/","",$updatePlugin->uri);
-		$packageUrl="https://api.github.com/repos/$repo/zipball/$tag";
-
-		$token=self::$options["github_access_token"];
-
-		if ($token)
-			$packageUrl.="?access_token=$token";
-
-		$current = get_site_transient( 'update_plugins' );
-
-		// We don't know which version we will be downloading, it will simply be the 
-		// one given by the tag. We pass NULL to "new_version" which isn't documented
-		// anywhere, but seems to work.
-		$transientEntry=array(
-			"slug"=>$updatePlugin->repo,
-			"plugin"=>$updatePlugin->slug,
-			"new_version"=>NULL,
-			"url"=>$updatePlugin->uri,
-			"package"=>$packageUrl
-		);
-
-		$current->response[$updatePlugin->slug]=(object)$transientEntry;
-		set_site_transient('update_plugins', $current);
-
-		$skin=new JsonUpgraderSkin();
-		$upgrader = new \Plugin_Upgrader($skin);
-		$upgrader->upgrade($updatePlugin->slug);
-
-		return $skin;
-	}
-
-	/**
 	 * Ajax endpoint for rest updates.
 	 */
 	public function ajax_update() {
-		$tag="master";
+		try {
+			$json_encode_flags=0;
+			if (defined("JSON_PRETTY_PRINT"))
+				$json_encode_flags=JSON_PRETTY_PRINT;
 
-		if (isset($_REQUEST["tag"]) && $_REQUEST["tag"])
-			$tag=$_REQUEST["tag"];
+			if (!isset($_REQUEST["key"]) || $_REQUEST["key"]!=get_site_option('github_updater_api_key'))
+ 				throw new \Exception("Bad api key.");
 
-		if (isset($_REQUEST["committish"]) && $_REQUEST["committish"])
-			$tag=$_REQUEST["committish"];
+			$tag="master";
+			if (isset($_REQUEST["tag"]) && $_REQUEST["tag"])
+				$tag=$_REQUEST["tag"];
 
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			if (isset($_REQUEST["committish"]) && $_REQUEST["committish"])
+				$tag=$_REQUEST["committish"];
 
-		if (isset($_REQUEST["plugin"]) && $_REQUEST["plugin"])
-			$upgraderSkin=$this->ajax_update_plugin($_REQUEST["plugin"],$tag);
+			$upgrader_skin=new JsonUpgraderSkin();
 
-		else if (isset($_REQUEST["theme"]) && $_REQUEST["theme"])
-			$upgraderSkin=$this->ajax_update_theme($_REQUEST["theme"],$tag);
+			if (isset($_REQUEST["plugin"]) && $_REQUEST["plugin"])
+				Plugin::instance()->update_single_plugin($_REQUEST["plugin"], $tag, $upgrader_skin);
 
-		else
-			$this->ajax_fail("No plugin or theme specified for update.");
+			else if (isset($_REQUEST["theme"]) && $_REQUEST["theme"])
+				Theme::instance()->update_single_theme($_REQUEST["theme"], $tag, $upgrader_skin);
 
-		$res=array(
-			"messages"=>$upgraderSkin->messages,
-		);
+			else
+				throw new \Exception("No plugin or theme specified for update.");
 
-		if ($upgraderSkin->error) {
+			if ($upgrader_skin->error)
+				throw new \Exception("Upgrade error.");
+		}
+
+		catch (\Exception $e) {
 			http_response_code(500);
-			$res["error"]=TRUE;
+			header('Content-Type: application/json');
+
+			echo json_encode(array(
+				"message"=>$e->getMessage(),
+				"error"=>TRUE
+			),$json_encode_flags);
+			exit;
 		}
 
-		else {
-			$res["success"]=TRUE;
-		}
+		header('Content-Type: application/json');
 
-		echo json_encode($res,JSON_PRETTY_PRINT);
+		echo json_encode(array(
+			"success"=>TRUE,
+			"messages"=>$upgrader_skin->messages,
+		),$json_encode_flags);
 		exit;
 	}
 

--- a/src/GitHub_Updater/JsonUpgraderSkin.php
+++ b/src/GitHub_Updater/JsonUpgraderSkin.php
@@ -18,6 +18,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
 /**
  * Class JsonUpgraderSkin
  *

--- a/src/GitHub_Updater/JsonUpgraderSkin.php
+++ b/src/GitHub_Updater/JsonUpgraderSkin.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * GitHub Updater
+ *
+ * @package   GitHub_Updater
+ * @author    Andy Fragen
+ * @license   GPL-2.0+
+ * @link      https://github.com/afragen/github-updater
+ */
+
+namespace Fragen\GitHub_Updater;
+
+/*
+ * Exit if called directly.
+ */
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Class JsonUpgraderSkin
+ *
+ * @package Fragen\GitHub_Updater
+ */
+class JsonUpgraderSkin extends \WP_Upgrader_Skin {
+
+	public $messages=array();
+	public $error;
+
+	public function feedback($string) {
+		if ( isset( $this->upgrader->strings[$string] ) )
+			$string = $this->upgrader->strings[$string];
+
+		if ( strpos($string, '%') !== false ) {
+			$args = func_get_args();
+			$args = array_splice($args, 1);
+			if ( $args ) {
+			    $args = array_map( 'strip_tags', $args );
+			    $args = array_map( 'esc_html', $args );
+			    $string = vsprintf($string, $args);
+			}
+		}
+		if ( empty($string) )
+			return;
+
+		//echo "$string\n";
+
+		$this->messages[]=$string;
+	}
+
+	public function error($errors) {
+		$this->error=TRUE;
+		parent::error($errors);
+	}
+
+	public function decrement_update_count() {
+	}
+
+    public function header() {
+    }
+
+	public function footer() {
+	}
+}

--- a/src/GitHub_Updater/Plugin.php
+++ b/src/GitHub_Updater/Plugin.php
@@ -193,35 +193,10 @@ class Plugin extends Base {
 	 */
 	public function get_remote_plugin_meta() {
 		foreach ( (array) $this->config as $plugin ) {
-			$this->repo_api = null;
-			switch( $plugin->type ) {
-				case 'github_plugin':
-					$this->repo_api = new GitHub_API( $plugin );
-					break;
-				case 'bitbucket_plugin':
-					$this->repo_api = new Bitbucket_API( $plugin );
-					break;
-				case 'gitlab_plugin';
-					$this->repo_api = new GitLab_API( $plugin );
-					break;
-			}
+			$this->get_single_remote_plugin_meta($plugin);
 
 			if ( is_null( $this->repo_api ) ) {
 				continue;
-			}
-
-			$this->{$plugin->type} = $plugin;
-			$this->set_defaults( $plugin->type );
-
-			if ( $this->repo_api->get_remote_info( basename( $plugin->slug ) ) ) {
-				$this->repo_api->get_repo_meta();
-				$this->repo_api->get_remote_tag();
-				$changelog = $this->get_changelog_filename( $plugin->type );
-				if ( $changelog ) {
-					$this->repo_api->get_remote_changes( $changelog );
-				}
-				$this->repo_api->get_remote_readme();
-				$plugin->download_link = $this->repo_api->construct_download_link();
 			}
 
 			/*
@@ -253,6 +228,77 @@ class Plugin extends Base {
 		$this->make_force_check_transient( 'plugins' );
 		set_site_transient( 'ghu_plugin', self::$object, ( self::$hours * HOUR_IN_SECONDS ) );
 		$this->load_pre_filters();
+	}
+
+	/**
+	 * Set up things for working with a particular plugin
+	 * from the $this->config array.
+	 */
+	protected function get_single_remote_plugin_meta($plugin) {
+		$this->repo_api = null;
+		switch( $plugin->type ) {
+			case 'github_plugin':
+				$this->repo_api = new GitHub_API( $plugin );
+				break;
+			case 'bitbucket_plugin':
+				$this->repo_api = new Bitbucket_API( $plugin );
+				break;
+			case 'gitlab_plugin';
+				$this->repo_api = new GitLab_API( $plugin );
+				break;
+		}
+
+		if ( is_null( $this->repo_api ) ) {
+			return;
+		}
+
+		$this->{$plugin->type} = $plugin;
+		$this->set_defaults( $plugin->type );
+
+		if ( $this->repo_api->get_remote_info( basename( $plugin->slug ) ) ) {
+			$this->repo_api->get_repo_meta();
+			$this->repo_api->get_remote_tag();
+			$changelog = $this->get_changelog_filename( $plugin->type );
+			if ( $changelog ) {
+				$this->repo_api->get_remote_changes( $changelog );
+			}
+			$this->repo_api->get_remote_readme();
+			$plugin->download_link = $this->repo_api->construct_download_link();
+		}
+	}
+
+	/**
+	 * Update a single plugin
+	 */
+	public function update_single_plugin($plugin_slug, $tag="master", $upgrader_skin=NULL) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		$plugin=NULL;
+
+		foreach ( (array) $this->config as $config_entry ) {
+			if ($config_entry->repo == $plugin_slug)
+				$plugin = $config_entry;
+		}
+
+		if (!$plugin)
+			throw new \Exception("Plugin not found: ".$plugin_slug);
+
+		$this->get_single_remote_plugin_meta($plugin);
+
+		$updates_transient = get_site_transient( 'update_plugins' );
+		$update=array(
+			"slug"=>$plugin->repo,
+			"plugin"=>$plugin->slug,
+			"new_version"=>NULL,
+			"url"=>$plugin->uri,
+			"package"=>$this->repo_api->construct_download_link( false, $tag )
+		);
+
+		$updates_transient->response[$plugin->slug]=(object)$update;
+		set_site_transient('update_plugins', $updates_transient);
+
+		$upgrader = new \Plugin_Upgrader($upgrader_skin);
+		$upgrader->upgrade($plugin->slug);
 	}
 
 	/**

--- a/src/GitHub_Updater/RestUpdate.php
+++ b/src/GitHub_Updater/RestUpdate.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * GitHub Updater
+ *
+ * @package   GitHub_Updater
+ * @author    Andy Fragen
+ * @author    Mikael Lindqvist
+ * @license   GPL-2.0+
+ * @link      https://github.com/afragen/github-updater
+ */
+
+namespace Fragen\GitHub_Updater;
+
+/*
+ * Exit if called directly.
+ */
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+/**
+ * Class RestUpdate
+ *
+ * Updates a single plugin or theme, in a way suitable for rest requests.
+ * This class inherits from Base in order to be able to call the
+ * set_defaults function.
+ *
+ * @package Fragen\GitHub_Updater
+ */
+class RestUpdate extends Base {
+
+	/**
+	 * Consruct.
+	 */
+	public function __construct() {
+		$this->upgrader_skin=new RestUpgraderSkin();
+	}
+
+	/**
+	 * Fill in some more information about the plugin. The code for this
+	 * function is more or less copy/pasted from the Plugin	class within
+	 * the get_remote_plugin_meta function.
+	 * Ideally this code should not exist in two places, so some some
+	 * refactoring could improve things.
+	 */
+	protected function get_single_remote_plugin_meta($plugin) {
+		$this->repo_api = null;
+		switch( $plugin->type ) {
+			case 'github_plugin':
+				$this->repo_api = new GitHub_API( $plugin );
+				break;
+			case 'bitbucket_plugin':
+				$this->repo_api = new Bitbucket_API( $plugin );
+				break;
+			case 'gitlab_plugin';
+				$this->repo_api = new GitLab_API( $plugin );
+				break;
+			default:
+				return;
+		}
+
+		$this->{$plugin->type} = $plugin;
+		$this->set_defaults( $plugin->type );
+
+		if ( $this->repo_api->get_remote_info( basename( $plugin->slug ) ) ) {
+			$this->repo_api->get_repo_meta();
+			$this->repo_api->get_remote_tag();
+			$changelog = $this->get_changelog_filename( $plugin->type );
+			if ( $changelog ) {
+				$this->repo_api->get_remote_changes( $changelog );
+			}
+			$this->repo_api->get_remote_readme();
+			$plugin->download_link = $this->repo_api->construct_download_link();
+		}
+	}
+
+	/**
+	 * Update plugin.
+	 */
+	public function update_plugin($plugin_slug, $tag="master") {
+		$plugin=NULL;
+
+		foreach ( (array) Plugin::instance()->get_plugin_configs() as $config_entry ) {
+			if ($config_entry->repo == $plugin_slug)
+				$plugin = $config_entry;
+		}
+
+		if (!$plugin)
+			throw new \Exception("Plugin not found: ".$plugin_slug);
+
+		$this->get_single_remote_plugin_meta($plugin);
+
+		$updates_transient = get_site_transient( 'update_plugins' );
+		$update=array(
+			"slug"=>$plugin->repo,
+			"plugin"=>$plugin->slug,
+			"new_version"=>NULL,
+			"url"=>$plugin->uri,
+			"package"=>$this->repo_api->construct_download_link( false, $tag )
+		);
+
+		$updates_transient->response[$plugin->slug]=(object)$update;
+		set_site_transient('update_plugins', $updates_transient);
+
+		$upgrader = new \Plugin_Upgrader($this->upgrader_skin);
+		$upgrader->upgrade($plugin->slug);
+	}
+
+	/**
+	 * Fill in some more information about the plugin. The code is copy
+	 * pasted from the Theme class, for further comments see the 
+	 * get_single_remote_plugin_meta function.
+	 */
+	protected function get_single_remote_theme_meta($theme) {
+		$this->repo_api = null;
+		switch( $theme->type ) {
+			case 'github_theme':
+				$this->repo_api = new GitHub_API( $theme );
+				break;
+			case 'bitbucket_theme':
+				$this->repo_api = new Bitbucket_API( $theme );
+				break;
+			case 'gitlab_theme':
+				$this->repo_api = new GitLab_API( $theme );
+				break;
+		}
+
+		if ( is_null( $this->repo_api ) ) {
+			return;
+		}
+
+		$this->{$theme->type} = $theme;
+		$this->set_defaults( $theme->type );
+
+		if ( $this->repo_api->get_remote_info( 'style.css' ) ) {
+			$this->repo_api->get_repo_meta();
+			$this->repo_api->get_remote_tag();
+			$changelog = $this->get_changelog_filename( $theme->type );
+			if ( $changelog ) {
+				$this->repo_api->get_remote_changes( $changelog );
+			}
+			$theme->download_link = $this->repo_api->construct_download_link();
+		}
+	}
+
+	/**
+	 * Update a single theme
+	 */
+	public function update_theme($theme_slug, $tag="master") {
+		$theme=NULL;
+
+		foreach ( (array) Theme::instance()->get_theme_configs() as $config_entry ) {
+			if ($config_entry->repo == $theme_slug)
+				$theme = $config_entry;
+		}
+
+		if (!$theme)
+			throw new \Exception("Theme not found: ".$theme_slug);
+
+		$this->get_single_remote_theme_meta($theme);
+
+		$updates_transient = get_site_transient( 'update_themes' );
+		$update=array(
+			"theme"=>$theme->repo,
+			"new_version"=>NULL,
+			"url"=>$theme->uri,
+			"package"=>$this->repo_api->construct_download_link( false, $tag )
+		);
+
+		$updates_transient->response[$theme->repo]=$update;
+		set_site_transient('update_themes', $updates_transient);
+
+		$upgrader = new \Theme_Upgrader($this->upgrader_skin);
+		$upgrader->upgrade($theme->repo);
+	}
+
+	/**
+	 * Is there an error?
+	 */
+	public function is_error() {
+		return $this->upgrader_skin->error;
+	}
+
+	/**
+	 * Get messages during update.
+	 */
+	public function get_messages() {
+		return $this->upgrader_skin->messages;
+	}
+
+	/**
+	 * Process request.
+	 * Relies on data in $_REQUEST, prints out json and exits.
+	 */
+	public function process_request() {
+		try {
+			$json_encode_flags=0;
+			if (defined("JSON_PRETTY_PRINT"))
+				$json_encode_flags=JSON_PRETTY_PRINT;
+
+			if (!isset($_REQUEST["key"]) || $_REQUEST["key"]!=get_site_option('github_updater_api_key'))
+ 				throw new \Exception("Bad api key.");
+
+			$tag="master";
+			if (isset($_REQUEST["tag"]) && $_REQUEST["tag"])
+				$tag=$_REQUEST["tag"];
+
+			if (isset($_REQUEST["committish"]) && $_REQUEST["committish"])
+				$tag=$_REQUEST["committish"];
+
+			if (isset($_REQUEST["plugin"]) && $_REQUEST["plugin"])
+				$this->update_plugin($_REQUEST["plugin"], $tag);
+
+			else if (isset($_REQUEST["theme"]) && $_REQUEST["theme"])
+				$this->update_theme($_REQUEST["theme"], $tag);
+
+			else
+				throw new \Exception("No plugin or theme specified for update.");
+		}
+
+		catch (\Exception $e) {
+			http_response_code(500);
+			header('Content-Type: application/json');
+
+			echo json_encode(array(
+				"message"=>$e->getMessage(),
+				"error"=>TRUE
+			),$json_encode_flags);
+			exit;
+		}
+
+		header('Content-Type: application/json');
+
+		$response=array(
+			"messages"=>$this->get_messages()
+		);
+
+		if ($this->is_error()) {
+			$response["error"]=TRUE;
+			http_response_code(500);
+		}
+
+		else {
+			$response["success"]=TRUE;
+		}
+
+		echo json_encode($response,$json_encode_flags);
+		exit;
+	}
+}

--- a/src/GitHub_Updater/RestUpgraderSkin.php
+++ b/src/GitHub_Updater/RestUpgraderSkin.php
@@ -1,10 +1,10 @@
 <?php
-
 /**
  * GitHub Updater
  *
  * @package   GitHub_Updater
  * @author    Andy Fragen
+ * @author    Mikael Lindqvist
  * @license   GPL-2.0+
  * @link      https://github.com/afragen/github-updater
  */
@@ -21,15 +21,22 @@ if ( ! defined( 'WPINC' ) ) {
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 /**
- * Class JsonUpgraderSkin
+ * Class RestUpgraderSkin
+ *
+ * Extends WP_Upgrader_Skin and collects outputed messages for later
+ * processing, rather than printing them out.
  *
  * @package Fragen\GitHub_Updater
  */
-class JsonUpgraderSkin extends \WP_Upgrader_Skin {
+class RestUpgraderSkin extends \WP_Upgrader_Skin {
 
 	public $messages=array();
 	public $error;
 
+	/**
+	 * Overrides the feedback method.
+	 * Adds the feedback string to the messages array.
+	 */
 	public function feedback($string) {
 		if ( isset( $this->upgrader->strings[$string] ) )
 			$string = $this->upgrader->strings[$string];
@@ -46,22 +53,32 @@ class JsonUpgraderSkin extends \WP_Upgrader_Skin {
 		if ( empty($string) )
 			return;
 
-		//echo "$string\n";
-
 		$this->messages[]=$string;
 	}
 
+	/**
+	 * Set the error flag to true, then let the base class handle the rest.
+	 */
 	public function error($errors) {
 		$this->error=TRUE;
 		parent::error($errors);
 	}
 
+	/**
+	 * Do nothing.
+	 */
 	public function decrement_update_count() {
 	}
 
+	/**
+	 * Do nothing.
+	 */
     public function header() {
     }
 
+	/**
+	 * Do nothing.
+	 */
 	public function footer() {
 	}
 }

--- a/src/GitHub_Updater/Settings.php
+++ b/src/GitHub_Updater/Settings.php
@@ -57,6 +57,8 @@ class Settings extends Base {
 	 * Start up
 	 */
 	public function __construct() {
+		$this->ensure_api_key_is_set();
+
 		add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', array( &$this, 'add_plugin_page' ) );
 		add_action( 'network_admin_edit_github-updater', array( &$this, 'update_network_setting' ) );
 		add_action( 'admin_init', array( &$this, 'page_init' ) );
@@ -590,7 +592,16 @@ class Settings extends Base {
 	 * Print the Remote Management text.
 	 */
 	public function print_section_remote_management() {
+		$api_key = get_site_option( 'github_updater_api_key' );
+
+		echo "<p>";
+		esc_html_e( 'Restful API for triggering updates is available at:', 'github-updater' );
+		echo "<br>";
+		echo "<tt>".admin_url("admin-ajax.php")."?action=github-updater-update&key=".$api_key."</tt>";
+		echo "</p>";
+		echo "<p>";
 		esc_html_e( 'Use of Remote Management services may result increase some page load speeds only for `admin` level users in the dashboard.', 'github-updater' );
+		echo "</p>";
 	}
 
 	/**

--- a/src/GitHub_Updater/Theme.php
+++ b/src/GitHub_Updater/Theme.php
@@ -83,6 +83,13 @@ class Theme extends Base {
 	}
 
 	/**
+	 * Returns an array of configurations for the known themes.
+	 */
+	public function get_theme_configs() {
+		return $this->config;
+	}
+
+	/**
 	 * Reads in WP_Theme class of each theme.
 	 * Populates variable array.
 	 *
@@ -190,10 +197,34 @@ class Theme extends Base {
 	 */
 	public function get_remote_theme_meta() {
 		foreach ( (array) $this->config as $theme ) {
-			$this->get_single_remote_theme_meta($theme);
+			$this->repo_api = null;
+			switch( $theme->type ) {
+				case 'github_theme':
+					$this->repo_api = new GitHub_API( $theme );
+					break;
+				case 'bitbucket_theme':
+					$this->repo_api = new Bitbucket_API( $theme );
+					break;
+				case 'gitlab_theme':
+					$this->repo_api = new GitLab_API( $theme );
+					break;
+			}
 
 			if ( is_null( $this->repo_api ) ) {
 				continue;
+			}
+
+			$this->{$theme->type} = $theme;
+			$this->set_defaults( $theme->type );
+
+			if ( $this->repo_api->get_remote_info( 'style.css' ) ) {
+				$this->repo_api->get_repo_meta();
+				$this->repo_api->get_remote_tag();
+				$changelog = $this->get_changelog_filename( $theme->type );
+				if ( $changelog ) {
+					$this->repo_api->get_remote_changes( $changelog );
+				}
+				$theme->download_link = $this->repo_api->construct_download_link();
 			}
 
 			/*
@@ -232,75 +263,6 @@ class Theme extends Base {
 		$this->make_force_check_transient( 'themes' );
 		set_site_transient( 'ghu_theme', self::$object, ( self::$hours * HOUR_IN_SECONDS ) );
 		$this->load_pre_filters();
-	}
-
-	/**
-	 * Set up things for working with a particular theme
-	 * from the $this->config array.
-	 */
-	protected function get_single_remote_theme_meta($theme) {
-		$this->repo_api = null;
-		switch( $theme->type ) {
-			case 'github_theme':
-				$this->repo_api = new GitHub_API( $theme );
-				break;
-			case 'bitbucket_theme':
-				$this->repo_api = new Bitbucket_API( $theme );
-				break;
-			case 'gitlab_theme':
-				$this->repo_api = new GitLab_API( $theme );
-				break;
-		}
-
-		if ( is_null( $this->repo_api ) ) {
-			return;
-		}
-
-		$this->{$theme->type} = $theme;
-		$this->set_defaults( $theme->type );
-
-		if ( $this->repo_api->get_remote_info( 'style.css' ) ) {
-			$this->repo_api->get_repo_meta();
-			$this->repo_api->get_remote_tag();
-			$changelog = $this->get_changelog_filename( $theme->type );
-			if ( $changelog ) {
-				$this->repo_api->get_remote_changes( $changelog );
-			}
-			$theme->download_link = $this->repo_api->construct_download_link();
-		}
-	}
-
-	/**
-	 * Update a single theme
-	 */
-	public function update_single_theme($theme_slug, $tag="master", $upgrader_skin=NULL) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-		$theme=NULL;
-
-		foreach ( (array) $this->config as $config_entry ) {
-			if ($config_entry->repo == $theme_slug)
-				$theme = $config_entry;
-		}
-
-		if (!$theme)
-			throw new \Exception("Theme not found: ".$theme_slug);
-
-		$this->get_single_remote_theme_meta($theme);
-
-		$updates_transient = get_site_transient( 'update_themes' );
-		$update=array(
-			"theme"=>$theme->repo,
-			"new_version"=>NULL,
-			"url"=>$theme->uri,
-			"package"=>$this->repo_api->construct_download_link( false, $tag )
-		);
-
-		$updates_transient->response[$theme->repo]=$update;
-		set_site_transient('update_themes', $updates_transient);
-
-		$upgrader = new \Theme_Upgrader($upgrader_skin);
-		$upgrader->upgrade($theme->repo);
 	}
 
 	/**


### PR DESCRIPTION
Pull request for the functionality discussed here: https://github.com/afragen/github-updater/issues/354

Short summary:

This PR makes it possible to access a URL in a RESTful way, and as a result update a single theme or plugin. The status of the update will come back as a JSON object. The URL to access is shown on the settings page, under the "Remote Management" tab. The parameters accepted by the URL:

* `key` - The key as displayed on the "Remote Management". Must match the key stored on the
  system.
* `plugin` - Specify this to update a particular plugin. Should be specified as only the name of the
  plugin as it is known to the system, not the remote repo.
* `theme` - Specify this to update a theme.
* `tag` - Specify a particular tag, branch or commit for the update. If nothing is specified, it defaults to
  "master".
* `committish` - This is an alias for the tag parameter. I think that referring to a "committish" is more
  correct in in terms of git terminology, but it sounds a bit funny so this is why I decided to treat the
  committish and tag parameters as aliases for each other.