### PR TITLE
Fixed Issue #380. Removed the warning message even if the GitLab private key is set.

### DIFF
--- a/src/GitHub_Updater/Messages.php
+++ b/src/GitHub_Updater/Messages.php
@@ -48,7 +48,7 @@ class Messages extends Base {
 		if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
 			switch ( $type ) {
 				case 'gitlab':
-					if ( ( empty( parent::$options['gitlab_enterprise_token'] ) ||
+					if ( ( empty( parent::$options['gitlab_enterprise_token'] ) &&
 					       empty( parent::$options['gitlab_private_token'] ) )
 					) {
 						add_action( 'admin_notices', array( __CLASS__, 'gitlab_error' ) );


### PR DESCRIPTION
Either the GitLab.com private key or the GitLab CE/Enterprises private key is required. Not the both.