### PR TITLE
Support MainWP

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -163,7 +163,7 @@ class Base {
 		foreach ( array_keys( Settings::$remote_management ) as $key ) {
 			// Remote management only needs to be active for admin pages.
 			if ( is_admin() && ! empty( self::$options_remote[ $key ] ) ) {
-				$admin_pages = array_merge( $admin_pages, array( 'index.php' ) );
+				$admin_pages = array_merge( $admin_pages, array( 'index.php', 'admin-ajax.php' ) );
 			}
 		}
 

--- a/src/GitHub_Updater/Settings.php
+++ b/src/GitHub_Updater/Settings.php
@@ -43,6 +43,7 @@ class Settings extends Base {
 		'ithemes_sync' => 'iThemes Sync',
 		'infinitewp'   => 'InfiniteWP',
 		'managewp'     => 'ManageWP',
+		'mainwp'       => 'MainWP',
 	);
 
 	/**


### PR DESCRIPTION
MainWP uses admin-ajax.php to hit the child sites, this is not yet supported in github-updater. I added this page to the allowed pages for a meta refresh and also added MainWP as a supported remote management system.

This is in reply to ticket #383.