### PR TITLE
Use theme and plugin dirname, if exists, instead of repo name

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -537,7 +537,7 @@ class Base {
 		 */
 		if ( $this instanceof Plugin &&
 		     ( defined( 'GITHUB_UPDATER_EXTENDED_NAMING' ) && GITHUB_UPDATER_EXTENDED_NAMING ) &&
-		     ( ! $this->config[ $repo['repo'] ]->dot_org ||
+		     ( ! $this->config[ $slug ]->dot_org ||
 		       ( $this->tag && 'master' !== $this->tag ) )
 		) {
 			$new_source = trailingslashit( $remote_source ) . $repo['extended_repo'];
@@ -570,10 +570,11 @@ class Base {
 			$upgrader_object = $this;
 		}
 
-		foreach ( $upgrader_object->config as $repo ) {
+		foreach ( $upgrader_object->config as $dirname => $repo ) {
 			if ( $slug === $repo->repo ||
 			     $slug === $repo->extended_repo ||
-			     $rename === $repo->owner . '-' . $repo->repo
+			     $rename === $repo->owner . '-' . $repo->repo ||
+			     $slug === $dirname
 			) {
 				$arr['repo']          = $repo->repo;
 				$arr['extended_repo'] = $repo->extended_repo;

--- a/src/GitHub_Updater/GitHub_API.php
+++ b/src/GitHub_Updater/GitHub_API.php
@@ -322,7 +322,7 @@ class GitHub_API extends API {
 		 */
 		if ( ! empty( $_GET['rollback'] ) &&
 		     ( isset( $_GET['action'] ) && 'upgrade-theme' === $_GET['action'] ) &&
-		     ( isset( $_GET['theme'] ) && $this->type->repo === $_GET['theme'] )
+		     ( isset( $_GET['theme'] ) && $this->type->slug === $_GET['theme'] )
 		) {
 			$endpoint .= $rollback;
 

--- a/src/GitHub_Updater/Plugin.php
+++ b/src/GitHub_Updater/Plugin.php
@@ -184,6 +184,7 @@ class Plugin extends Base {
 				) );
 				$git_plugin['branch']              = ! empty( $headers[ $repo_parts['branch'] ] ) ? $headers[ $repo_parts['branch'] ] : 'master';
 				$git_plugin['slug']                = $plugin;
+//				$git_plugin['dirname']          =
 				$git_plugin['local_path']          = WP_PLUGIN_DIR . '/' . $header['repo'] . '/';
 				$git_plugin['local_path_extended'] = WP_PLUGIN_DIR . '/' . $git_plugin['extended_repo'] . '/';
 
@@ -198,7 +199,8 @@ class Plugin extends Base {
 				$git_plugin['dot_org'] = true;
 			}
 
-			$git_plugins[ $git_plugin['repo'] ] = (object) $git_plugin;
+//			$git_plugins[ $git_plugin['repo'] ] = (object) $git_plugin;
+			$git_plugins[ dirname( $git_plugin['slug'] ) ] = (object) $git_plugin;
 		}
 
 		return $git_plugins;
@@ -277,7 +279,7 @@ class Plugin extends Base {
 
 		if ( ! empty( $plugin ) ) {
 			$id       = $plugin['repo'] . '-id';
-			$branches = isset( $this->config[ $plugin['repo'] ] ) ? $this->config[ $plugin['repo'] ]->branches : null;
+			$branches = isset( $this->config[ dirname( $plugin_file ) ] ) ? $this->config[ dirname( $plugin_file ) ]->branches : null;
 		} else {
 			return false;
 		}
@@ -343,7 +345,7 @@ class Plugin extends Base {
 		/*
 		 * Remove 'Visit plugin site' link in favor or 'View details' link.
 		 */
-		if ( array_key_exists( $repo, $this->config ) ) {
+		if ( array_key_exists( dirname( $file ), $this->config ) ) {
 			if ( ! is_null( $repo ) ) {
 				unset( $links[2] );
 				$links[] = sprintf( '<a href="%s" class="thickbox">%s</a>',


### PR DESCRIPTION
If you manually install a plugin/theme, and give it a dirname, which is common, then the updater should use that dirname, rather than searching for the repository slug. In many cases, the repository slug is not what I want the dirname in my site to be.

Example. Say I have an organization named "Cool Stuff" and I have a plugin in that organization named "plugin-a". I may want the site this applies to have the plugin installed in "cool-stuff-plugin-a", rather than just "plugin-a".

Anyways, I don't know that I covered all grounds here with the refactor, but I think I'm close. And that's all this PR is, a refactor of the usages of the `$theme->repo` and replacing with `$theme->slug`, basically. Same for plugins.