### PR TITLE
Needs PHP Zip extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Contributors: [Andy Fragen](https://github.com/afragen), [Gary Jones](https://github.com/GaryJones), [Seth Carstens](https://github.com/scarstens), [Mikael Lindqvist](https://github.com/limikael), [contributors](https://github.com/afragen/github-updater/graphs/contributors)
 * Tags: plugin, theme, update, updater, github, bitbucket, gitlab, remote install
 * Requires at least: 4.0
-* Requires PHP: 5.3
+* Requires PHP: 5.3 (and `php-zip`)
 * Tested up to: 4.6
 * Stable tag: master
 * Donate link: http://thefragens.com/github-updater-donate


### PR DESCRIPTION
WordPress Version: 4.6.1
PHP Version:       7.0.11-1+deb.sury.org~xenial+1

on Ubuntu 16.04 and I had the plugin failing with 

> The package could not be installed. PCLZIP_ERR_BAD_FORMAT (-10) : Invalid archive structure

until I installed `php-zip`. Maybe there could be a better error message because is was just a guess and the message itself does not really point to the solution.