### PR TITLE
filters for wp_rest_cache

### DIFF
--- a/src/GitHub_Updater/API.php
+++ b/src/GitHub_Updater/API.php
@@ -211,7 +211,7 @@ abstract class API extends Base {
 		}
 
 		// Allows advanced caching plugins to control REST transients to avoid double caching
-		if ( false === apply_filters( 'ghu_use_remote_call_transients', true, $id, $response ) ) {
+		if ( false === apply_filters( 'ghu_use_remote_call_transients', true ) ) {
 			return false;
 		}
 		return get_site_transient( $transient );

--- a/src/GitHub_Updater/API.php
+++ b/src/GitHub_Updater/API.php
@@ -210,6 +210,10 @@ abstract class API extends Base {
 			self::$transients[] = $transient;
 		}
 
+		// Allows advanced caching plugins to control REST transients to avoid double caching
+		if ( false === apply_filters( 'ghu_use_remote_call_transients', true, $id, $response ) ) {
+			return false;
+		}
 		return get_site_transient( $transient );
 	}
 
@@ -227,6 +231,11 @@ abstract class API extends Base {
 		$this->response[ $id ] = $response;
 		if ( ! in_array( $transient, self::$transients, true ) ) {
 			self::$transients[] = $transient;
+		}
+
+		// Allows advanced caching plugins to control REST transients to avoid double caching
+		if ( false === apply_filters( 'ghu_use_remote_call_transients', true, $id, $response ) ) {
+			return false;
 		}
 		set_site_transient( $transient, $this->response, ( self::$hours * HOUR_IN_SECONDS ) );
 

--- a/src/GitHub_Updater/API.php
+++ b/src/GitHub_Updater/API.php
@@ -214,6 +214,7 @@ abstract class API extends Base {
 		if ( false === apply_filters( 'ghu_use_remote_call_transients', true ) ) {
 			return false;
 		}
+
 		return get_site_transient( $transient );
 	}
 


### PR DESCRIPTION
allows disabling transients in order to stop double caching