### PR TITLE
Treat gitlab group as the repo owner

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -840,37 +840,16 @@ class Base {
 	 *
 	 * @param string $repo_header
 	 *
-	 * @return array $header
+	 * @return array
 	 */
 	protected function parse_header_uri( $repo_header ) {
-		$header_parts               = parse_url( $repo_header );
-		$header['scheme']           = isset( $header_parts['scheme'] ) ? $header_parts['scheme'] : null;
-		$header['host']             = isset( $header_parts['host'] ) ? $header_parts['host'] : null;
-		$path                       = trim( $header_parts['path'], '/' );  // strip surrounding slashes
-		$path                       = str_replace( '.git', '', $path ); //strip incorrect URI ending
-		$header['path']             = $path;
-		$path                       = explode( '/', $path );
-		$header['owner']            = array_shift( $path );
-		$header['repo']             = array_pop( $path );
-		$group                      = empty( $path )
-			? null
-			: array_map( function( $e ) {
-				if ( ! empty( $e ) ) {
-					return $e;
-				}
-			}, $path );
-		$header['group']            = null === $group
-			? $group
-			: implode( '/', $group );
-		$header['owner_repo']       = isset( $header['owner'] )
-			? implode( '/', array( $header['owner'], $header['repo'] ) )
-			: null;
-		$header['owner_group_repo'] = isset( $header['owner'], $header['group'] )
-			? implode( '/', array( $header['owner'], $header['group'], $header['repo'], ) )
-			: $header['owner_repo'];
-		$header['base_uri']         = str_replace( $header_parts['path'], '', $repo_header );
-		$header['uri']              = isset( $header['scheme'] ) ? trim( $repo_header, '/' ) : null;
-
+		$header = parse_url( $repo_header );
+		$header['repo'] = pathinfo($header['path'], PATHINFO_FILENAME);
+		$header['owner'] = trim(pathinfo($header['path'], PATHINFO_DIRNAME), '/');
+		$header['base_uri'] = str_replace( $header['path'], '', $repo_header );
+		$header['path'] = $header['owner_repo'] = sprintf("%s/%s", $header['owner'], $header['repo']); 
+		$header['uri'] = isset( $header['scheme'] ) ? trim( $repo_header, '/' ) : null;
+		
 		$header = Settings::sanitize( $header );
 
 		return $header;


### PR DESCRIPTION
Hi,

I've made some changes to my local copy of the plugin to support GitLab's grouping feature not knowing that there is already a branch for this. 

I'm still submitting my pull request to see if we can learn from it. To my understanding in GitLab, a group is the actual owner of the repository. We should then treat it that way and avoid complication and new array elements/variables.

Let me know what do you think. I'm happy how this branch works, I'm just throwing this out there as an idea to consider.