### PR TITLE
Update Basic_Auth_Loader.php

### DIFF
--- a/src/GitHub_Updater/Basic_Auth_Loader.php
+++ b/src/GitHub_Updater/Basic_Auth_Loader.php
@@ -161,6 +161,17 @@ class Basic_Auth_Loader {
 				Singleton::get_instance( 'Theme' )->get_theme_configs()
 			)
 			: false;
+		
+		if ( ! $slug ) {
+			if (isset($repos) && is_array($repos)) {
+				foreach ($repos as $repo) {
+					if ($repo->download_link == $url) {
+						$slug = dirname($repo->slug);
+					}
+				}
+			}
+		}
+		
 		$type  = $slug && $repos &&
 		         isset( $repos[ $slug ] ) && property_exists( $repos[ $slug ], 'type' )
 			? $repos[ $slug ]->type


### PR DESCRIPTION
Bugfix for https://github.com/afragen/github-updater/issues/607

If the BasicAuthLoader will be called from wp cli "wp plugin update <pluginname>"
$slug remains empty, and it returns an object of configs, created by the previous Singleton::get_instance( 'Plugin' )->get_plugin_configs(),

This fix makes sure it looks for the matching slug, and returns the type property as mean't in the statement below,
so that it goes into the switch statement correctly, and adds authentication headers.