### PR TITLE
Clear cached options

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -882,13 +882,14 @@ class Base {
 	 * @return bool
 	 */
 	public function delete_all_cached_data() {
-		global $wpdb;
+        $plugins = Singleton::get_instance( 'Plugin' )->get_plugin_configs();
+        $themes  = Singleton::get_instance( 'Theme' )->get_theme_configs();
 
-		$table         = is_multisite() ? $wpdb->base_prefix . 'sitemeta' : $wpdb->base_prefix . 'options';
-		$column        = is_multisite() ? 'meta_key' : 'option_name';
-		$delete_string = 'DELETE FROM ' . $table . ' WHERE ' . $column . ' LIKE %s LIMIT 1000';
+        $repos = array_merge( $plugins, $themes );
 
-		$wpdb->query( $wpdb->prepare( $delete_string, array( '%ghu-%' ) ) );
+        foreach( $repos as $repo ) {
+            delete_site_option( 'ghu-' . md5( $repo->repo ) );
+        }
 
 		$this->force_run_cron_job();
 


### PR DESCRIPTION
Hello Mr. Andy. Thank you so much for your great plugin. It very helpful and great.
Looks like I found 1 place that can work incorrectly if persistent object cache used on site
Delete option in this way, will not delete them from cache. So, looks like options must be deleted via delete_site_option