### PR TITLE
Adding cache refresh to remote API

### DIFF
--- a/src/GitHub_Updater/Rest_Update.php
+++ b/src/GitHub_Updater/Rest_Update.php
@@ -140,6 +140,14 @@ class Rest_Update extends Base {
 		$upgrader = new \Theme_Upgrader( $this->upgrader_skin );
 		$upgrader->upgrade( $theme->repo );
 	}
+	
+	/**
+	 * Refresh the cache.
+	 */
+	public function refresh_cache() {
+		$this->delete_all_cached_data();
+		$this->upgrader_skin->messages[] = "Cache refreshed successfully.";
+	}
 
 	/**
 	 * Is there an error?
@@ -204,6 +212,8 @@ class Rest_Update extends Base {
 				$this->update_plugin( $_REQUEST['plugin'], $tag );
 			} elseif ( isset( $_REQUEST['theme'] ) ) {
 				$this->update_theme( $_REQUEST['theme'], $tag );
+			} elseif ( isset( $_REQUEST['refresh_cache'] ) ) {
+				$this->refresh_cache();
 			} else {
 				throw new \UnexpectedValueException( 'No plugin or theme specified for update.' );
 			}


### PR DESCRIPTION
I added this because I wanted to automatically trigger a cache refresh after updating my own custom themes and plugins. On a live site it's not always advantageous to automatically install the updates after publishing...I may want to do some testing first on a non-production site before installing my latest updates. But I do want the cache refreshed so I can immediately update from my WP admin panel as soon as I feel comfortable with the new code.