### PR TITLE
Do not prepend base_uri to full GitHub Enterprise URLs

### DIFF
--- a/src/GitHub_Updater/API.php
+++ b/src/GitHub_Updater/API.php
@@ -426,6 +426,7 @@ class API {
 				}
 				if ( $this->type->enterprise_api ) {
 					$type['base_download'] = $this->type->enterprise_api;
+					$type['base_uri']      = null;
 					if ( $download_link ) {
 						break;
 					}


### PR DESCRIPTION
When providing a full URL to an GitHub Enterprise hosted repo, e.g. `https://:GHE_HOST/api/v3/repos/:GHE_ORG/:GHE_REPO`, the used URL resolves to an invalid URL `https://api.github.comhttps://:GHE_HOST/api/v3/repos/:GHE_ORG/:GHE_REPO/contents/style.css`, because the API host is always being prepended.