### PR TITLE
Fix for 1password on Chrome autofilling the GitHub Access Token field

### DIFF
--- a/src/GitHub_Updater/API/Bitbucket_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_API.php
@@ -491,7 +491,7 @@ class Bitbucket_API extends API implements API_Interface {
 	public function bitbucket_password() {
 		?>
 		<label for="bitbucket_password">
-			<input class="bitbucket_setting" type="password" style="width:50%;" name="bitbucket_password" value="">
+			<input class="bitbucket_setting" type="password" style="width:50%;" name="bitbucket_password" value="" autocomplete="new-password">
 			<br>
 			<span class="description">
 				<?php esc_html_e( 'Enter Bitbucket password.', 'github-updater' ); ?>

--- a/src/GitHub_Updater/API/GitHub_API.php
+++ b/src/GitHub_Updater/API/GitHub_API.php
@@ -467,7 +467,7 @@ class GitHub_API extends API implements API_Interface {
 	public function github_access_token() {
 		?>
 		<label for="github_access_token">
-			<input class="github_setting" type="password" style="width:50%;" name="github_access_token" value="">
+			<input class="github_setting" type="password" style="width:50%;" name="github_access_token" value="" autocomplete="new-password">
 			<br>
 			<span class="description">
 				<?php esc_html_e( 'Enter GitHub Access Token for private GitHub repositories.', 'github-updater' ); ?>

--- a/src/GitHub_Updater/API/GitLab_API.php
+++ b/src/GitHub_Updater/API/GitLab_API.php
@@ -536,7 +536,7 @@ class GitLab_API extends API implements API_Interface {
 	public function gitlab_access_token() {
 		?>
 		<label for="gitlab_access_token">
-			<input class="gitlab_setting" type="password" style="width:50%;" name="gitlab_access_token" value="">
+			<input class="gitlab_setting" type="password" style="width:50%;" name="gitlab_access_token" value="" autocomplete="new-password">
 			<br>
 			<span class="description">
 				<?php esc_html_e( 'Enter GitLab Access Token for private GitLab repositories.', 'github-updater' ); ?>

--- a/src/GitHub_Updater/API/Gitea_API.php
+++ b/src/GitHub_Updater/API/Gitea_API.php
@@ -392,7 +392,7 @@ class Gitea_API extends API implements API_Interface {
 	public function gitea_access_token() {
 		?>
 		<label for="gitea_access_token">
-			<input class="gitea_setting" type="password" style="width:50%;" name="gitea_access_token" value="">
+			<input class="gitea_setting" type="password" style="width:50%;" name="gitea_access_token" value="" autocomplete="new-password">
 			<br>
 			<span class="description">
 				<?php esc_html_e( 'Enter Gitea Access Token for private Gitea repositories.', 'github-updater' ); ?>


### PR DESCRIPTION
The 1Password browser extension on Chrome tries to be too smart, and autofills any `GitHub Access Token` fields with the credentials for the WordPress site itself:

![image](https://user-images.githubusercontent.com/125274/47744367-45568980-dc25-11e8-9dd4-526880612cbc.png)

This pull request simply uses the suggested practice from MDN to prevent autocomplete on password fields that aren't meant to be autofilled.
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields

Thanks!