### PR TITLE
Request Bitbucket tags sorted in descending order

### DIFF
--- a/src/GitHub_Updater/API/Bitbucket_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_API.php
@@ -109,7 +109,7 @@ class Bitbucket_API extends API implements API_Interface {
 	 * @return bool
 	 */
 	public function get_remote_tag() {
-		return $this->get_remote_api_tag( 'bitbucket', '/2.0/repositories/:owner/:repo/refs/tags' );
+		return $this->get_remote_api_tag( 'bitbucket', '/2.0/repositories/:owner/:repo/refs/tags?sort=-name' );
 	}
 
 	/**


### PR DESCRIPTION
This change ensures that the latest tag is returned on the first page of the response. It is possible with the default ascending(ish) sort for new tags to appear on the second or later results page causing the plugin to download older tags instead (#752).

For reference, `sort=-name` should sort correctly for semver tags, not entirely clear how to interpret this for other tag formats:
> The name field is handled specially for tags in that, if specified as the sort field, it uses a natural sort order instead of the default lexicographical sort order. For example, it will return ['1.1', '1.2', '1.10'] instead of ['1.1', '1.10', '1.2'].