### PR TITLE
add a quick link in the admin bar to the refresh transients feature

### DIFF
--- a/src/GitHub_Updater/Settings.php
+++ b/src/GitHub_Updater/Settings.php
@@ -88,6 +88,7 @@ class Settings extends Base {
 	 */
 	protected function load_hooks() {
 		add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'add_plugin_page' ] );
+		add_action('admin_bar_menu', [ $this, 'add_quick_clear_cache_link' ], 100 );
 		add_action( 'network_admin_edit_github-updater', [ $this, 'update_settings' ] );
 
 		add_filter(
@@ -174,6 +175,20 @@ class Settings extends Base {
 			'github-updater',
 			[ $this, 'create_admin_page' ]
 		);
+	}
+
+	/**
+	 * Add Admin Bar quick clear cache link.
+	 */
+	public function add_quick_clear_cache_link($admin_bar) {
+		$admin_bar->add_menu( array(
+			'id'    => 'github-updater-quick-clear-cache',
+			'title' => 'GitHub Refresh',
+			'href'  => '/wp-admin/options.php?github_updater_refresh_transients=1',
+			'meta'  => array(
+				'title' => __('GitHub Refresh'),
+			),
+		) );
 	}
 
 	/**


### PR DESCRIPTION
I find I'm constantly needing to access this feature on sites I manage with GitHub Updater. It would be convenient to be able to access this directly from any place in WordPress - front or back end. This would turn a process of 2 or 3 clicks/page loads into 1 click.

The only thing I'm not sure of it compatibility w/ multisite, which I see is important based on your other code. I don't think `network_admin_bar_menu` exists, does it?