### PR TITLE
Use WP's temp directory

### DIFF
--- a/src/GitHub_Updater/Readme_Parser.php
+++ b/src/GitHub_Updater/Readme_Parser.php
@@ -45,7 +45,7 @@ class Readme_Parser extends Parser {
 	 * @return void
 	 */
 	public function __construct( $file ) {
-		$file_path = WP_CONTENT_DIR . '/tmp-readme.txt';
+		$file_path = get_temp_dir() . '/' . md5sum( $file ) . '-tmp-readme.txt';
 
 		/**
 		 * Filter location of temporary readme filepath.

--- a/src/GitHub_Updater/Readme_Parser.php
+++ b/src/GitHub_Updater/Readme_Parser.php
@@ -45,7 +45,7 @@ class Readme_Parser extends Parser {
 	 * @return void
 	 */
 	public function __construct( $file ) {
-		$file_path = get_temp_dir() . '/' . md5sum( $file ) . '-tmp-readme.txt';
+		$file_path = get_temp_dir() . '/' . md5( $file ) . '-tmp-readme.txt';
 
 		/**
 		 * Filter location of temporary readme filepath.


### PR DESCRIPTION
Use get_temp_dir() so that the temporary directory is as used elsewhere, and a writeable one s picked. Also make the filename less predictable (in case it's a shared temporary directory).