### PR TITLE
Repos with a '.' in their name were not re-connected properly

### DIFF
--- a/src/GitHub_Updater/Traits/GHU_Trait.php
+++ b/src/GitHub_Updater/Traits/GHU_Trait.php
@@ -331,7 +331,7 @@ trait GHU_Trait {
 		$header['scheme']     = isset( $header_parts['scheme'] ) ? $header_parts['scheme'] : null;
 		$header['host']       = isset( $header_parts['host'] ) ? $header_parts['host'] : null;
 		$header['owner']      = trim( $header_path['dirname'], '/' );
-		$header['repo']       = $header_path['filename'];
+		$header['repo']       = $header_path['basename'];
 		$header['owner_repo'] = implode( '/', [ $header['owner'], $header['repo'] ] );
 		$header['base_uri']   = str_replace( $header_parts['path'], '', $repo_header );
 		$header['uri']        = isset( $header['scheme'] ) ? trim( $repo_header, '/' ) : null;


### PR DESCRIPTION
I have a repo on github that has a '.' in its name. On GHU's settings page, I had this error message : 
![image](https://user-images.githubusercontent.com/2527227/65433003-8139a500-de1c-11e9-9741-8da073353cfe.png)

This simple fix uses `basename` - which contains the complete file name, with extension - rather than `filename` - which does not contains the extension.
