### PR TITLE
Optimize cron job scheduling

### DIFF
--- a/src/GitHub_Updater/Plugin.php
+++ b/src/GitHub_Updater/Plugin.php
@@ -254,7 +254,7 @@ class Plugin {
 
 		$schedule_event = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ? is_main_site() : true;
 
-		if ( $schedule_event ) {
+		if ( $schedule_event && ! empty ( $plugins ) ) {
 			if ( ! wp_next_scheduled( 'ghu_get_remote_plugin' ) &&
 			! $this->is_duplicate_wp_cron_event( 'ghu_get_remote_plugin' ) &&
 			! apply_filters( 'github_updater_disable_wpcron', false )

--- a/src/GitHub_Updater/Theme.php
+++ b/src/GitHub_Updater/Theme.php
@@ -251,7 +251,7 @@ class Theme {
 
 		$schedule_event = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ? is_main_site() : true;
 
-		if ( $schedule_event ) {
+		if ( $schedule_event && ! empty ( $themes ) ) {
 			if ( ! wp_next_scheduled( 'ghu_get_remote_theme' ) &&
 			! $this->is_duplicate_wp_cron_event( 'ghu_get_remote_theme' ) &&
 			! apply_filters( 'github_updater_disable_wpcron', false )


### PR DESCRIPTION
Something I noticed while checking out #825: the cron job needs to be scheduled only if there are plugins/themes to be processed by it - spares some CPU time :-)

NB.: both `get_remote_plugin_meta` and `get_remote_theme_meta` methods could be optimized as well, but I'll open an issue for that first.