### PR TITLE
Add filters for Bitbucket Server API endpoints

### DIFF
--- a/src/GitHub_Updater/API/Bitbucket_Server_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_Server_API.php
@@ -54,12 +54,12 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	public function get_remote_info( $file ) {
 
 		/**
-		* Filter to return the Bitbucket API path
+		* Filter to return the Bitbucket API path to browse repo
 		*
 		* @since 9.3.2.3
 		* @return string
 		*/
-		$path = apply_filters( 'github_updater_bitbucket_api_path', '/1.0/:owner/repos/:repo/browse/' );
+		$path = apply_filters( 'github_updater_bitbucket_api_path_browse', '/1.0/:owner/repos/:repo/browse/' );
 		return $this->get_remote_api_info( 'bbserver', $file, $path . "{$file}" );
 	}
 
@@ -69,7 +69,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_repo_meta() {
-		return $this->get_remote_api_repo_meta( 'bbserver', '/1.0/:owner/repos/:repo' );
+		/**
+		* Filter to return the Bitbucket API path for the repo
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_path', '/1.0/:owner/repos/:repo' );
+		return $this->get_remote_api_repo_meta( 'bbserver', $path );
 	}
 
 	/**
@@ -80,7 +87,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_remote_tag() {
-		return $this->get_remote_api_tag( 'bbserver', '/1.0/:owner/repos/:repo/tags' );
+		/**
+		* Filter to return the Bitbucket API path for the repo
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_tags', '/1.0/:owner/repos/:repo/tags' );
+		return $this->get_remote_api_tag( 'bbserver', $path );
 	}
 
 	/**
@@ -89,7 +103,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_remote_readme() {
-		return $this->get_remote_api_readme( 'bbserver', '/1.0/:owner/repos/:repo/raw/readme.txt' );
+		/**
+		* Filter to return the Bitbucket API path for the repo
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_readme', '/1.0/:owner/repos/:repo/raw/readme.txt' );
+		return $this->get_remote_api_readme( 'bbserver', $path );
 	}
 
 	/**
@@ -100,7 +121,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_remote_changes( $changes ) {
-		return $this->get_remote_api_changes( 'bbserver', $changes, "/1.0/:owner/repos/:repo/raw/{$changes}" );
+		/**
+		* Filter to return the Bitbucket API path for the repo
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_changes', '"/1.0/:owner/repos/:repo/raw/' );
+		return $this->get_remote_api_changes( 'bbserver', $changes, $path . "{$changes}" );
 	}
 
 	/**
@@ -109,7 +137,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_remote_branches() {
-		return $this->get_remote_api_branches( 'bbserver', '/1.0/:owner/repos/:repo/branches' );
+		/**
+		* Filter to return the Bitbucket API path for the repo
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_branches', '/1.0/:owner/repos/:repo/branches' );
+		return $this->get_remote_api_branches( 'bbserver', $path );
 	}
 
 	/**

--- a/src/GitHub_Updater/API/Bitbucket_Server_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_Server_API.php
@@ -54,7 +54,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	public function get_remote_info( $file ) {
 
 		/**
-		* Filter to return the Bitbucket API path to browse repo
+		* Filter to return the Bitbucket API path to repo/browse endpoint
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -70,7 +70,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function get_repo_meta() {
 		/**
-		* Filter to return the Bitbucket API path for the repo
+		* Filter to return the Bitbucket API path for the repo endpoint
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -88,7 +88,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function get_remote_tag() {
 		/**
-		* Filter to return the Bitbucket API path for the repo
+		* Filter to return the Bitbucket API path for the repo tags endpoint
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -104,7 +104,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function get_remote_readme() {
 		/**
-		* Filter to return the Bitbucket API path for the repo
+		* Filter to return the Bitbucket API path for the repo readme file (raw)
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -122,7 +122,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function get_remote_changes( $changes ) {
 		/**
-		* Filter to return the Bitbucket API path for the repo
+		* Filter to return the Bitbucket API path for the repo to evaluate changes (raw)
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -138,7 +138,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function get_remote_branches() {
 		/**
-		* Filter to return the Bitbucket API path for the repo
+		* Filter to return the Bitbucket API path for the repo branches endpoint
 		*
 		* @since 9.3.2.3
 		* @return string
@@ -173,7 +173,7 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	public function construct_download_link( $branch_switch = false ) {
 		self::$method       = 'download_link';
 		/**
-		* Filter to return the Bitbucket API path for the download link
+		* Filter to return the Bitbucket API path for the repo archive endpoint (download link)
 		*
 		* @since 9.3.2.3
 		* @return string

--- a/src/GitHub_Updater/API/Bitbucket_Server_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_Server_API.php
@@ -172,7 +172,14 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 */
 	public function construct_download_link( $branch_switch = false ) {
 		self::$method       = 'download_link';
-		$download_link_base = $this->get_api_url( '/latest/:owner/repos/:repo/archive', true );
+		/**
+		* Filter to return the Bitbucket API path for the download link
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$download_path = apply_filters( 'github_updater_bitbucket_api_download_link', '/latest/:owner/repos/:repo/archive' );
+		$download_link_base = $this->get_api_url( $download_path, true );
 		$endpoint           = $this->add_endpoints( $this, '' );
 
 		if ( $branch_switch ) {

--- a/src/GitHub_Updater/API/Bitbucket_Server_API.php
+++ b/src/GitHub_Updater/API/Bitbucket_Server_API.php
@@ -52,7 +52,15 @@ class Bitbucket_Server_API extends Bitbucket_API {
 	 * @return bool
 	 */
 	public function get_remote_info( $file ) {
-		return $this->get_remote_api_info( 'bbserver', $file, "/1.0/:owner/repos/:repo/browse/{$file}" );
+
+		/**
+		* Filter to return the Bitbucket API path
+		*
+		* @since 9.3.2.3
+		* @return string
+		*/
+		$path = apply_filters( 'github_updater_bitbucket_api_path', '/1.0/:owner/repos/:repo/browse/' );
+		return $this->get_remote_api_info( 'bbserver', $file, $path . "{$file}" );
 	}
 
 	/**


### PR DESCRIPTION
This PR allows for customization of the Bitbucket Server API endpoints to support different versions. 
Example code shows how to use the proposed filters to add the expected /projects/ path to the endpoint.

It has been tested with Bitbucket Server 5.4 and the [documentation suggests that is valid up to latest v7.X](https://docs.atlassian.com/bitbucket-server/rest/7.0.0/bitbucket-rest.html). 

May be a direct resolution for #830 
```
//Customize the Rest API endpoints for Github updater to include the /projects/ path in multiple endpoints
add_filter( 'github_updater_bitbucket_api_path_browse', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_path', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_tags', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_readme', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_changes', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_branches', 'bitbucket_api_path_modify' );
add_filter( 'github_updater_bitbucket_api_download_link', 'bitbucket_api_path_modify' );
function bitbucket_api_path_modify( $path ) {
	if( false !== strpos( $path, '/1.0/:owner' ) ) {
		$old_path = $path;
		$parts = explode( '/1.0/:owner', $path );
		$path = '/1.0/projects/:owner' . $parts[1];
	}

	if( false !== strpos( $path, '/latest/:owner' ) ) {
		$old_path = $path;
		$parts = explode( '/latest/:owner', $path );
		$path  = '/latest/projects/:owner' . $parts[1];
	}
	return $path;
}
```