### PR TITLE
Stop showing all these warnings

### DIFF
--- a/src/GitHub_Updater/Traits/GHU_Trait.php
+++ b/src/GitHub_Updater/Traits/GHU_Trait.php
@@ -610,6 +610,8 @@ trait GHU_Trait {
 	 */
 	public function is_duplicate_wp_cron_event( $event ) {
 		$cron = _get_cron_array();
+		if (!$cron)
+			return false;
 		foreach ( $cron as $timestamp => $cronhooks ) {
 			if ( key( $cronhooks ) === $event ) {
 				$this->is_cron_overdue( $cron, $timestamp );


### PR DESCRIPTION
As documented, `_get_cron_array()` can return `false` if there are no tasks. This generates a PHP warning in the server log, possibly multiple times each minute, like this:

```
[Wed Jun 10 08:34:43.594146 2020] [php7:warn] [pid 20160] [client 172.18.0.3:56296] PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/wp-content/plugins/github-updater/src/GitHub_Updater/Traits/GHU_Trait.php on line 615
```

Added "fail fast" to stop these messages.