### PR TITLE
Make the branch switching list table row visually incorporated into the row for the plugin/theme it is for...

### DIFF
--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -766,7 +766,7 @@ class Base {
 				$githost = str_replace( "{$type_cap}URI", '', $key );
 				$padding = is_rtl() ? 'padding-left: 6px;' : 'padding-right: 6px;';
 				$icon    = sprintf(
-					'<img src="%s" style="vertical-align:text-bottom;%s" height="16" width="16" alt="%s" />',
+					'<img src="%1$s" style="vertical-align:text-bottom;%2$s" height="16" width="16" alt="%3$s" />',
 					plugins_url( basename( constant( __NAMESPACE__ . '\DIR' ) ) . '/assets/' . $git_icons[ strtolower( $githost ) ] ),
 					$add_padding ? $padding : '',
 					$githost

--- a/src/GitHub_Updater/Base.php
+++ b/src/GitHub_Updater/Base.php
@@ -606,7 +606,7 @@ class Base {
 			"jQuery( 'tr:not([id])[{$data_attr}=\"%s\"]' ).addClass( 'update' );",
 			$file
 		);
-		// Removes the bottom "line" for the shinny update row (if any).
+		// Removes the bottom "line" for the shiny update row (if any).
 		printf(
 			"jQuery( 'tr[id][{$data_attr}=\"%s\"] td' ).css( 'box-shadow', 'none' );",
 			$file


### PR DESCRIPTION
..., just like normal update rows,

Also adds the git host icon to the branch switching row in the same place where normal update rows have the "recycle" icon, to make it more clear that that row is added by GHU.

With this PR applied, the plugins screen might look like:

![gnu-branch-swithing](https://user-images.githubusercontent.com/3824560/92332701-f22d9900-f03c-11ea-8c55-f59c11da173b.png)
