### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    tags:
+      - "**"
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get tag
+        id: tag
+        run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+
+      - name: Build project
+        run: git archive -o /tmp/github-updater-${{ steps.tag.outputs.tag }}.zip --prefix=github-updater/ ${{ steps.tag.outputs.tag }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          release_name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/github-updater-${{ steps.tag.outputs.tag }}.zip
+          asset_name: github-updater-${{ steps.tag.outputs.tag }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This PR adds a release workflow which will run when a new tag is pushed. 
It will create a release with the same name as the tag and attach the asset.